### PR TITLE
Output reports with gatling-compatible filename

### DIFF
--- a/src/clj_gatling/core.clj
+++ b/src/clj_gatling/core.clj
@@ -9,15 +9,17 @@
                                                  path-join
                                                  weighted-scenarios
                                                  choose-runner
-                                                 timestamp-str]]
+                                                 create-report-name]]
             [clj-gatling.simulation :as simulation]))
 
 (def buffer-size 20000)
 
-(defn- create-results-dir [root]
-  (let [results-dir (path-join root (timestamp-str))]
-    (create-dir (path-join results-dir "input"))
-    results-dir))
+(defn- create-results-dir 
+  ([root] (create-results-dir root nil))
+  ([root simulation-name]
+   (let [results-dir (path-join root (create-report-name simulation-name))]
+     (create-dir (path-join results-dir "input"))
+     results-dir)))
 
 ;Legacy function for running tests with old format (pre 0.8)
 (defn run-simulation [legacy-scenarios concurrency & [options]]
@@ -47,7 +49,7 @@
                             root "target/results"
                             timeout-in-ms 5000
                             context {}}}]
-  (let [results-dir (create-results-dir root)
+  (let [results-dir (create-results-dir root (:name simulation))
         reporter (or reporter (gatling-highcharts-reporter results-dir))
         result (simulation/run simulation {:concurrency concurrency
                                            :concurrency-distribution concurrency-distribution

--- a/src/clj_gatling/simulation_util.clj
+++ b/src/clj_gatling/simulation_util.clj
@@ -1,7 +1,8 @@
 (ns clj-gatling.simulation-util
   (:require [clj-time.core :as t]
             [clj-time.format :as f]
-            [clojure.java.io :as io])
+            [clojure.java.io :as io]
+            [clojure.string :as str])
   (:import [java.util List]
            [java.io File]
            [java.io StringWriter PrintWriter]
@@ -87,3 +88,9 @@
 (defn timestamp-str []
   (let [custom-formatter (f/formatter "yyyyMMddHHmmssSSS")]
     (f/unparse custom-formatter (t/now))))
+
+(defn create-report-name
+  "Create a gatling compatible filename for report output: 'SimulationName-Timestamp'"
+  [simulation-name]
+  (let [sanitized-prefix (str/replace (or simulation-name "empty_name") #"[^a-zA-Z0-9_]" "")]
+    (str sanitized-prefix "-" (timestamp-str))))


### PR DESCRIPTION
SBT Gatling, and the jenkins gatling plugin, require reports to be output in a directory with the format: "SimulationName-Timestamp" (See https://github.com/jenkinsci/gatling-plugin/blob/master/src/main/java/io/gatling/jenkins/GatlingPublisher.java#L156).  

Current clj-gatling code only outputs the timestamp.  This code will add the simulation name into the report.  Otherwise utilizing the jenkins gatling plugin fails the build and will not publish graphs and archive the reports.