### PR TITLE
deps edn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ pom.xml
 pom.xml.asc
 .lein*
 .nrepl*
+/.cpcache/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+repl:
+	clj -A:dev
+
+test:
+	clj -A:dev:test
+
+.PHONY: repl test

--- a/README.md
+++ b/README.md
@@ -10,9 +10,8 @@ Create and run load tests using Clojure (and get fancy reports).
 
 Add the following to your `project.clj` `:dependencies`:
 
-```clojure
-[clj-gatling "0.15.1"]
-```
+[![Clojars Project](https://img.shields.io/clojars/v/clj-gatling.svg)](https://clojars.org/clj-gatling)
+
 
 ## Usage
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,19 @@
+{:deps
+ {org.clojure/clojure {:mvn/version "1.10.1"},
+  org.clojure/core.async {:mvn/version "1.2.603"},
+  http-kit/http-kit {:mvn/version "2.3.0"},
+  clj-time/clj-time {:mvn/version "0.15.2"},
+  prismatic/schema {:mvn/version "1.1.12"},
+  clojider-gatling-highcharts-reporter/clojider-gatling-highcharts-reporter {:mvn/version "0.2.2"}}
+ :aliases
+ {:test
+  {:extra-paths ["test"]
+   :main-opts ["-m" "cognitect.test-runner"]
+   :extra-deps
+   {com.cognitect/test-runner {:git/url "https://github.com/cognitect-labs/test-runner.git"
+                               :sha "62ef1de18e076903374306060ac0e8a752e57c86"}}}
+
+  :dev
+  {:extra-deps {clj-async-test/clj-async-test {:mvn/version "0.0.5"}
+               org.clojure/test.check {:mvn/version "1.1.0"}
+               clj-containment-matchers/clj-containment-matchers {:mvn/version "1.0.1"}}}}}


### PR DESCRIPTION
Just added a deps.edn file since it makes it easier to work on this project.
I didn't copy exactly everything from the project.clj, but it would be easy to port the remaining settings.
Tests and the repl are already working with `make repl` and `make test`.

Also using the clojars markdown snippet for the project version makes it easier to keep it updated imho.