### PR TITLE
Add error reasons to Gatling Highcharts reporter

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -3,7 +3,7 @@
   org.clojure/core.async                                                    {:mvn/version "1.3.622"},
   http-kit/http-kit                                                         {:mvn/version "2.5.3"},
   prismatic/schema                                                          {:mvn/version "1.1.12"},
-  clojider-gatling-highcharts-reporter/clojider-gatling-highcharts-reporter {:mvn/version "0.3.1"}}
+  clojider-gatling-highcharts-reporter/clojider-gatling-highcharts-reporter {:mvn/version "0.3.2"}}
  :aliases
  {:dev
   {:extra-deps {clj-time/clj-time                                 {:mvn/version "0.15.2"},

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clj-gatling "0.17.0"
+(defproject clj-gatling "0.17.1"
   :description "Clojure library for load testing"
   :url "http://github.com/mhjort/clj-gatling"
   :license {:name "Eclipse Public License"
@@ -7,7 +7,7 @@
                  [org.clojure/core.async "1.3.622"]
                  [http-kit "2.5.3"]
                  [prismatic/schema "1.1.12"]
-                 [clojider-gatling-highcharts-reporter "0.3.1"]]
+                 [clojider-gatling-highcharts-reporter "0.3.2"]]
   :profiles {:dev {:global-vars {*warn-on-reflection* false}
                    :source-paths ["examples"]
                    :dependencies [[clj-time "0.15.2"]

--- a/src/clj_gatling/reporters/raw_reporter.clj
+++ b/src/clj_gatling/reporters/raw_reporter.clj
@@ -19,17 +19,17 @@
    :collector 'clj-gatling.reporters.raw-reporter/collector
    :generator 'clj-gatling.reporters.raw-reporter/generator})
 
-(defn- write-ends-as-lines [file-name lines]
+(defn- write-edns-as-lines [file-name lines]
   (with-open [wtr (BufferedWriter. (FileWriter. file-name))]
     (loop [lines-left lines]
-      (let [line (pr-str (first lines-left))]
-        (.write wtr line)
+      (let [line (first lines-left)]
+        (.write wtr (pr-str line))
         (when (seq (rest lines-left))
           (.newLine wtr)
           (recur (rest lines-left)))))))
 
-(defn- append-edns-as-lines [writer ends]
-  (doseq [edn ends]
+(defn- append-edns-as-lines [writer edns]
+  (doseq [edn edns]
     (.write writer (pr-str edn))
     (.newLine writer)))
 
@@ -48,7 +48,7 @@
     (let [writer (BufferedWriter. (FileWriter. (raw-file-name results-dir)))]
       {:collect (fn [_ {:keys [batch node-id batch-id]}]
                   (let [file-name (str results-dir "/batch-" node-id "-" batch-id ".log")]
-                    (write-ends-as-lines file-name batch)
+                    (write-edns-as-lines file-name batch)
                     [writer file-name]))
        :combine (fn [param1 param2]
                   (doseq [[writer file-name] [param1 param2]]

--- a/src/clj_gatling/simulation.clj
+++ b/src/clj_gatling/simulation.clj
@@ -32,8 +32,6 @@
             (parse-response (<! response))
             (parse-response response)))
         (catch Exception e
-          {:result false :end-time (now) :context ctx :exception e})
-        (catch AssertionError e
           {:result false :end-time (now) :context ctx :exception e})))))
 
 (defn async-function-with-timeout [step timeout sent-requests user-id original-context]

--- a/src/clj_gatling/simulation_util.clj
+++ b/src/clj_gatling/simulation_util.clj
@@ -167,3 +167,19 @@
        first
        ((fn [^java.lang.reflect.Method x] (.getParameterTypes x)))
        java.lang.reflect.Array/getLength))
+
+(defn failure-message
+  "Generates a Gatling-suitable failure message for returned errors. Drops the
+  data from ExceptionInfo structures, as it would be too complex. Drops the
+  class from AssertionError, Exception, ExceptionInfo, and Throwable, as it is
+  not useful. Stringifies the error in all other cases."
+  [ex]
+  (if (or (some #{(class ex)} [AssertionError Exception Throwable])
+          (instance? clojure.lang.ExceptionInfo ex))
+    (ex-message ex)
+    (str ex)))
+
+(defn clean-result [result]
+  (if (:exception result)
+    (update result :exception failure-message)
+    result))

--- a/test/clj_gatling/simulation_test.clj
+++ b/test/clj_gatling/simulation_test.clj
@@ -127,7 +127,7 @@
                                      :context-after map?
                                      :result true}]}]))))
 
-(deftest when-function-returns-exception-it-is-handled-as-ko
+(deftest when-function-throws-exception-it-is-handled-as-ko
   (let [s {:name "Exception scenario"
            :steps [{:name "Throwing" :request (fn [_] (throw (Exception. "Simulated")))}]}
         result (run-single-scenario s :concurrency 1)]
@@ -141,7 +141,25 @@
                                      :end number?
                                      :context-before map?
                                      :context-after map?
-                                     :result false}]}]))))
+                                     :result false
+                                     :exception "Simulated"}]}]))))
+
+(deftest when-function-returns-exception-it-is-handled-as-ko
+  (let [s {:name "Exception scenario"
+           :steps [{:name "Throwing" :request (fn [_] (Exception. "Simulated"))}]}
+        result (run-single-scenario s :concurrency 1)]
+    (is (equal? result [{:name "Exception scenario"
+                         :id 0
+                         :start number?
+                         :end number?
+                         :requests [{:name "Throwing"
+                                     :id 0
+                                     :start number?
+                                     :end number?
+                                     :context-before map?
+                                     :context-after map?
+                                     :result false
+                                     :exception "Simulated"}]}]))))
 
 (deftest when-function-throws-exception-it-is-logged
   (delete-error-logs)
@@ -507,7 +525,8 @@
                                      :end number?
                                      :context-before map?
                                      :context-after map?
-                                     :result false}]}]))))
+                                     :result false
+                                     :exception "clj-gatling: request timed out"}]}]))))
 
 (deftest with-2-arity-concurrency-function
   (let [concurrency-function-called? (atom false)

--- a/test/clj_gatling/simulation_util_test.clj
+++ b/test/clj_gatling/simulation_util_test.clj
@@ -79,3 +79,20 @@
   (is (= 1 (simulation-util/arg-count (fn [x]))))
   (is (= 2 (simulation-util/arg-count (fn [x y]))))
   (is (= 3 (simulation-util/arg-count (fn [x y z])))))
+
+(deftest failure-message
+  (is (= "Assert failed: (= 1 2)"
+         (simulation-util/failure-message (AssertionError. "Assert failed: (= 1 2)"))))
+  (is (= "Exception message"
+         (simulation-util/failure-message (Exception. "Exception message"))))
+  (is (= "ExceptionInfo message"
+         (simulation-util/failure-message (ex-info "ExceptionInfo message" {:data "foo"}))))
+  (is (= "Throwable message"
+         (simulation-util/failure-message (Throwable. "Throwable message"))))
+  (is (= "java.lang.RuntimeException: RuntimeException message"
+         (simulation-util/failure-message (RuntimeException. "RuntimeException message")))))
+
+(deftest clean-result
+  (is (= {:result true} (simulation-util/clean-result {:result true})))
+  (is (= {:result false :exception "Message"}
+         (simulation-util/clean-result {:result false :exception (Exception. "Message")}))))


### PR DESCRIPTION
Depends on: https://github.com/mhjort/clojider-gatling-highcharts-reporter/pull/2

This uses the modifications to the Gatling Highcharts reporter
(mhjort/clojider-gatling-highcharts-reporter#2)
to record a breakdown of the types of failure that occur. User-defined
request functions simply need to throw the exception for this to be
triggered.

Given that some libraries (e.g. `httpkit`) return a clojure
`ExceptionInfo` in a failed response it is also useful to check the
response for a directly returned exception object, rather than requiring
it to be thrown.