### PR TITLE
Catch `AssertionError` thrown by step-fn

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clj-gatling "0.17.1"
+(defproject clj-gatling "0.17.2"
   :description "Clojure library for load testing"
   :url "http://github.com/mhjort/clj-gatling"
   :license {:name "Eclipse Public License"

--- a/src/clj_gatling/simulation.clj
+++ b/src/clj_gatling/simulation.clj
@@ -32,6 +32,8 @@
             (parse-response (<! response))
             (parse-response response)))
         (catch Exception e
+          {:result false :end-time (now) :context ctx :exception e})
+        (catch AssertionError e
           {:result false :end-time (now) :context ctx :exception e})))))
 
 (defn async-function-with-timeout [step timeout sent-requests user-id original-context]


### PR DESCRIPTION
Fixes https://github.com/mhjort/clj-gatling/issues/81

`(assert ...)` is a useful form for checking the status of a step, but
`AssertionError` inherits from `Throwable`, not `Exception`. We don't
want to catch _all_ throwables, as that includes things like
`VirtualMachineError`, which indicate a fundamental issue where the only
thing to do is exit.

As such, we special-case `AssertionError` as a type to catch alongside
`Exception`.