### PR TITLE
Add support for force stop functionality

### DIFF
--- a/src/clj_gatling/core.clj
+++ b/src/clj_gatling/core.clj
@@ -70,12 +70,12 @@
                             root "target/results"
                             executor pipeline/local-executor
                             nodes 1
-                            progress-tracker (progress-tracker/create-console-progress-tracker)
                             timeout-in-ms 5000
                             context {}}}]
   (validate schema/Options options)
   (let [simulation-name (:name (eval-if-needed simulation))
         results-dir (create-results-dir root simulation-name)
+        default-progress-tracker (progress-tracker/create-console-progress-tracker)
         multiple-reporters? (not (nil? reporters))
         reporters (or reporters
                       (create-reporters reporter results-dir simulation))
@@ -87,7 +87,8 @@
                                                 :timeout-in-ms timeout-in-ms
                                                 :context context
                                                 :executor executor
-                                                :progress-tracker progress-tracker
+                                                :progress-tracker (or progress-tracker default-progress-tracker)
+                                                :default-progress-tracker default-progress-tracker
                                                 :reporters reporters
                                                 :results-dir results-dir
                                                 :nodes nodes

--- a/src/clj_gatling/progress_tracker.clj
+++ b/src/clj_gatling/progress_tracker.clj
@@ -16,6 +16,7 @@
           (flush))))))
 
 (defn start [{:keys [progress-tracker
+                     default-progress-tracker
                      runner
                      force-stop-fn
                      sent-requests
@@ -31,6 +32,7 @@
                        (progress-tracker {:progress progress
                                           :sent-requests @sent-requests
                                           :total-concurrency total-concurrency
+                                          :default-progress-tracker default-progress-tracker
                                           :force-stop-fn force-stop-fn}))
                      (catch Exception e
                        (println "Failed to run progress tracker" progress-tracker "with exception" e))))]

--- a/src/clj_gatling/progress_tracker.clj
+++ b/src/clj_gatling/progress_tracker.clj
@@ -15,7 +15,12 @@
           ;;Flush is required for forcing writing to console in every round
           (flush))))))
 
-(defn start [{:keys [progress-tracker runner sent-requests start-time scenario-concurrency-trackers]}]
+(defn start [{:keys [progress-tracker
+                     runner
+                     force-stop-fn
+                     sent-requests
+                     start-time
+                     scenario-concurrency-trackers]}]
   (let [executor (Executors/newSingleThreadScheduledExecutor)
         stop-fn (fn []
                   (.shutdownNow executor))
@@ -25,7 +30,8 @@
                            total-concurrency (reduce + (map deref (vals scenario-concurrency-trackers)))]
                        (progress-tracker {:progress progress
                                           :sent-requests @sent-requests
-                                          :total-concurrency total-concurrency}))
+                                          :total-concurrency total-concurrency
+                                          :force-stop-fn force-stop-fn}))
                      (catch Exception e
                        (println "Failed to run progress tracker" progress-tracker "with exception" e))))]
     (.scheduleAtFixedRate executor runnable 10 200 TimeUnit/MILLISECONDS)

--- a/src/clj_gatling/simulation.clj
+++ b/src/clj_gatling/simulation.clj
@@ -262,7 +262,8 @@
                              concurrency-distribution
                              rate
                              rate-distribution
-                             progress-tracker] :as options}
+                             progress-tracker
+                             default-progress-tracker] :as options}
                      scenarios]
   (println "Running simulation with"
            (runners/runner-info runner)
@@ -288,6 +289,7 @@
                                                        :sent-requests sent-requests
                                                        :start-time simulation-start
                                                        :scenario-concurrency-trackers scenario-concurrency-trackers
+                                                       :default-progress-tracker default-progress-tracker
                                                        :progress-tracker progress-tracker})
         run-scenario-with-opts (fn [{:keys [name] :as scenario}]
                                  (run-scenario (if rate

--- a/src/clj_gatling/simulation.clj
+++ b/src/clj_gatling/simulation.clj
@@ -314,7 +314,7 @@
           (close! results)
           (stop-progress-tracker)
           (when post-hook (post-hook context)))))
-    results))
+    {:results results :force-stop-fn force-stop-fn}))
 
 (defn run [{:keys [scenarios pre-hook post-hook] :as simulation}
            {:keys [concurrency rate users context] :as options}]

--- a/src/clj_gatling/simulation.clj
+++ b/src/clj_gatling/simulation.clj
@@ -9,7 +9,7 @@
                                                  weighted-scenarios]]
             [schema.core :refer [validate]]
             [clj-gatling.timers :as timers]
-            [clojure.core.async :as async :refer [go go-loop close! alts! <! >!]])
+            [clojure.core.async :as async :refer [go go-loop close! alts! <! >! poll!]])
   (:import (java.time Duration LocalDateTime)))
 
 (set! *warn-on-reflection* true)
@@ -82,7 +82,14 @@
     :else
     [nil context [nil nil]]))
 
-(defn- run-scenario-once [{:keys [runner simulation-start] :as options}
+(defn- continue-run? [{:keys [runner sent-requests simulation-start next-run-at force-stop-ch]}]
+  (if (poll! force-stop-ch)
+    (do
+      (println "Force stop requested. Not starting new scenarios anymore")
+      false)
+    (runners/continue-run? runner sent-requests simulation-start next-run-at)))
+
+(defn- run-scenario-once [{:keys [runner force-stop-ch simulation-start] :as options}
                           {:keys [pre-hook post-hook] :as scenario} user-id]
   (let [timeout (:timeout-in-ms options)
         sent-requests (:sent-requests options)
@@ -90,13 +97,17 @@
         skip-next-after-failure? (if (nil? (:skip-next-after-failure? scenario))
                                    true
                                    (:skip-next-after-failure? scenario))
-        should-terminate? #(and (:allow-early-termination? scenario)
-                                (not (runners/continue-run? runner @sent-requests simulation-start (LocalDateTime/now))))
         request-failed? #(not (:result %))
         merged-context (or (merge (:context options) (:context scenario)) {})
         final-context (if pre-hook
                         (pre-hook merged-context)
                         merged-context)
+        should-terminate? #(and (:allow-early-termination? scenario)
+                                (not (continue-run? {:runner runner
+                                                     :force-stop-ch force-stop-ch
+                                                     :sent-requests @sent-requests
+                                                     :simulation-start simulation-start
+                                                     :next-run-at (LocalDateTime/now)})))
         step-ctx [(:steps scenario) (:step-fn scenario)]]
     (go-loop [[step context step-ctx] (next-step step-ctx final-context)
               results []]
@@ -122,6 +133,7 @@
 (defn- run-concurrent-scenario-constantly
   [{:keys [concurrent-scenarios
            runner
+           force-stop-ch
            sent-requests
            simulation-start
            concurrency
@@ -152,7 +164,11 @@
             (swap! concurrent-scenarios dec)
             (>! c result)))
         (<! (timers/timeout 200)))
-      (if (runners/continue-run? runner @sent-requests simulation-start (LocalDateTime/now))
+      (if (continue-run? {:runner runner
+                          :sent-requests @sent-requests
+                          :simulation-start simulation-start
+                          :next-run-at (LocalDateTime/now)
+                          :force-stop-ch force-stop-ch})
         (recur)
         (close! c)))
     c))
@@ -175,6 +191,7 @@
   [{:keys [concurrent-scenarios
            run-tracker
            runner
+           force-stop-ch
            rate-distribution
            prepared-requests
            sent-requests
@@ -203,7 +220,11 @@
             pending  (swap! prepared-requests inc)]
         ;;This means we only wait if there are not already enough waiting
         ;;requests to complete the scenario
-        (if (runners/continue-run? runner pending simulation-start next-run)
+        (if (continue-run? {:runner runner
+                            :sent-requests pending
+                            :simulation-start simulation-start
+                            :next-run-at next-run
+                            :force-stop-ch force-stop-ch})
           (let [t (LocalDateTime/now)]
             (when (.isBefore t next-run)
               (<! (timers/timeout (.toMillis (Duration/between t next-run)))))
@@ -256,11 +277,14 @@
   (let [simulation-start (LocalDateTime/now)
         prepared-requests (atom 0)
         sent-requests (atom 0)
+        force-stop-ch (async/chan)
+        force-stop-fn #(async/put! force-stop-ch true)
         scenario-concurrency-trackers (reduce (fn [m k] (assoc m k (atom 0))) {} (map :name scenarios))
         rate-run-trackers (when rate
                             (reduce (fn [m k] (assoc m k (atom simulation-start))) {} (map :name scenarios)))
         ;;TODO Maybe use try-finally for stopping
         stop-progress-tracker (progress-tracker/start {:runner runner
+                                                       :force-stop-fn force-stop-fn
                                                        :sent-requests sent-requests
                                                        :start-time simulation-start
                                                        :scenario-concurrency-trackers scenario-concurrency-trackers
@@ -272,6 +296,7 @@
                                                (assoc options
                                                  :concurrent-scenarios (get scenario-concurrency-trackers name)
                                                  :run-tracker (get rate-run-trackers name)
+                                                 :force-stop-ch force-stop-ch
                                                  :simulation-start simulation-start
                                                  :prepared-requests prepared-requests
                                                  :sent-requests sent-requests)

--- a/test/clj_gatling/pipeline_test.clj
+++ b/test/clj_gatling/pipeline_test.clj
@@ -1,5 +1,5 @@
 (ns clj-gatling.pipeline-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [deftest is]]
             [clj-gatling.test-helpers :as th]
             [clj-containment-matchers.clojure-test :refer :all]
             [clj-gatling.pipeline :as pipeline]))
@@ -21,16 +21,17 @@
         executor (stub-executor node-ids)
         reporters [th/a-reporter
                    th/b-reporter]
-        summary (pipeline/run 'clj-gatling.example/test-simu {:executor executor
-                                                              :nodes 3
-                                                              :context {}
-                                                              :results-dir "tmp"
-                                                              :concurrency 5
-                                                              :requests 25
-                                                              :timeout-in-ms 1000
-                                                              :progress-tracker (fn [_])
-                                                              :batch-size 10
-                                                              :reporters reporters})]
+        {:keys [summary force-stop-fn]} (pipeline/run 'clj-gatling.example/test-simu {:executor executor
+                                                                                      :nodes 3
+                                                                                      :context {}
+                                                                                      :results-dir "tmp"
+                                                                                      :concurrency 5
+                                                                                      :requests 25
+                                                                                      :timeout-in-ms 1000
+                                                                                      :progress-tracker (fn [_])
+                                                                                      :batch-size 10
+                                                                                      :reporters reporters})]
     ;;Stub reporter returns number of batches parsed per reporter
-    (is (equal? summary {:a 3 :b 3}))
+    (force-stop-fn) ;;Makes sure that calling force-stop-fn does not throw an exception
+    (is (equal? @summary {:a 3 :b 3}))
     (is (= #{0 1 2} @node-ids))))

--- a/test/clj_gatling/pipeline_test.clj
+++ b/test/clj_gatling/pipeline_test.clj
@@ -1,7 +1,6 @@
 (ns clj-gatling.pipeline-test
   (:require [clojure.test :refer [deftest is]]
             [clj-gatling.test-helpers :as th]
-            [clj-containment-matchers.clojure-test :refer :all]
             [clj-gatling.pipeline :as pipeline]))
 
 (deftest max-users
@@ -33,5 +32,5 @@
                                                                                       :reporters reporters})]
     ;;Stub reporter returns number of batches parsed per reporter
     (force-stop-fn) ;;Makes sure that calling force-stop-fn does not throw an exception
-    (is (equal? @summary {:a 3 :b 3}))
+    (is (= {:a 3 :b 3} @summary))
     (is (= #{0 1 2} @node-ids))))

--- a/test/clj_gatling/simulation_test.clj
+++ b/test/clj_gatling/simulation_test.clj
@@ -645,14 +645,19 @@
       (is (= (sort @duration-distribution) @duration-distribution)))))
 
 (deftest progress-tracker-is-called-if-defined
-  (let [progress-tracker-call-count (atom 0)]
+  (let [progress-tracker-call-count (atom 0)
+        default-progress-tracker-defined? (atom true)]
     (run-single-scenario {:name "progress-tracker-scenario"
                           :steps [(step "step" true)]}
                          :concurrency 1
                          :duration (Duration/ofMillis 500)
-                         :progress-tracker (fn [_]
+                         :default-progress-tracker (fn [_])
+                         :progress-tracker (fn [{:keys [default-progress-tracker]}]
+                                             (when-not (fn? default-progress-tracker)
+                                               (reset! default-progress-tracker-defined? false))
                                              (swap! progress-tracker-call-count inc)))
-    (is (< 1 @progress-tracker-call-count))))
+    (is (< 1 @progress-tracker-call-count))
+    (is (= true @default-progress-tracker-defined?))))
 
 (deftest scenario-weight
   (let [main-scenario {:name "Main"

--- a/test/clj_gatling/simulation_test.clj
+++ b/test/clj_gatling/simulation_test.clj
@@ -578,19 +578,6 @@
       (is (> (count @duration-distribution) 10))
       (is (= (sort @duration-distribution) @duration-distribution)))))
 
-(deftest with-rate
-  (let [progress-distribution (atom [])]
-    (run-single-scenario {:name "scenario"
-                          :steps [(step "step" true)]}
-                         :rate 100
-                         :users (range 10)
-                         :requests 100
-                         :context {:value 1})
-    (testing "Progress goes from 0 to 1"
-      (is (every? #(and (>= % 0.0) (<= % 1.0)) @progress-distribution))
-      (is #{0.1} @progress-distribution)
-      (is #{1.0} @progress-distribution)
-      (is (= (sort @progress-distribution) @progress-distribution)))))
 
 (deftest with-2-arity-rate-function
   (let [rate-function-called? (atom false)

--- a/test/clj_gatling/simulation_test.clj
+++ b/test/clj_gatling/simulation_test.clj
@@ -528,6 +528,19 @@
                                      :result false
                                      :exception "clj-gatling: request timed out"}]}]))))
 
+(defn- every-other-element [xs]
+  (first (apply map list (partition 2 xs))))
+
+(defn- is-approximately-sorted? [xs]
+  ;; Original vector might contain small incontingencies
+  ;; It could for example look like this [1 0 3 4 5 6]
+  ;; This should be counted as a sorted list eventhough there is
+  ;; a one outlier. Therefore we try to remove every other element
+  ;; before the comparison
+  (let [cleaned-xs (every-other-element xs)
+        sorted-cleaned-xs (sort cleaned-xs)]
+    (is (= sorted-cleaned-xs cleaned-xs) "vector should be sorted")))
+
 (deftest with-2-arity-concurrency-function
   (let [concurrency-function-called? (atom false)
         context-to-fn (atom {})
@@ -552,7 +565,7 @@
       (is (every? #(and (>= % 0.0) (<= % 1.0)) @progress-distribution))
       (is #{0.1} @progress-distribution)
       (is #{1.0} @progress-distribution)
-      (is (= (sort @progress-distribution) @progress-distribution)))))
+      (is-approximately-sorted? @progress-distribution))))
 
 (deftest with-1-arity-concurrency-function
   (let [concurrency-function-called? (atom false)
@@ -576,8 +589,7 @@
       (is (= {:value 1} @context-to-fn)))
     (testing "Duration has ordered values"
       (is (> (count @duration-distribution) 10))
-      (is (= (sort @duration-distribution) @duration-distribution)))))
-
+      (is-approximately-sorted? @duration-distribution))))
 
 (deftest with-2-arity-rate-function
   (let [rate-function-called? (atom false)
@@ -604,7 +616,7 @@
       (is (every? #(and (>= % 0.0) (<= % 1.0)) @progress-distribution))
       (is #{0.1} @progress-distribution)
       (is #{1.0} @progress-distribution)
-      (is (= (sort @progress-distribution) @progress-distribution)))))
+      (is-approximately-sorted? @progress-distribution))))
 
 (deftest with-1-arity-rate-function
   (let [rate-function-called? (atom false)
@@ -629,7 +641,8 @@
       (is (= {:value 1} @context-to-fn)))
     (testing "Duration has ordered values"
       (is (> (count @duration-distribution) 10))
-      (is (= (sort @duration-distribution) @duration-distribution)))))
+      (is-approximately-sorted? @duration-distribution))))
+
 
 (deftest progress-tracker-is-called-if-defined
   (let [progress-tracker-call-count (atom 0)

--- a/test/clj_gatling/test_helpers.clj
+++ b/test/clj_gatling/test_helpers.clj
@@ -36,6 +36,7 @@
                                    :error-file error-file-path
                                    :progress-tracker (fn [_])}
                                   (weighted-scenarios (range concurrency) scenarios))
+        :results
         to-vector)))
 
 (defn run-single-scenario [scenario & {:keys [concurrency
@@ -53,31 +54,31 @@
                                               post-hook]
                                        :or {timeout-in-ms 5000
                                             progress-tracker (fn [_])}}]
-  (to-vector (simulation/run {:name "Simulation"
-                              :pre-hook pre-hook
-                              :post-hook post-hook
-                              :scenarios [scenario]}
-                             {:concurrency concurrency
-                              :concurrency-distribution concurrency-distribution
-                              :rate rate
-                              :rate-distribution rate-distribution
-                              :timeout-in-ms timeout-in-ms
-                              :requests requests
-                              :duration duration
-                              :users users
-                              :context context
-                              :error-file error-file-path
-                              :default-progress-tracker default-progress-tracker
-                              :progress-tracker progress-tracker})))
+  (to-vector (:results (simulation/run {:name "Simulation"
+                                        :pre-hook pre-hook
+                                        :post-hook post-hook
+                                        :scenarios [scenario]}
+                                       {:concurrency concurrency
+                                        :concurrency-distribution concurrency-distribution
+                                        :rate rate
+                                        :rate-distribution rate-distribution
+                                        :timeout-in-ms timeout-in-ms
+                                        :requests requests
+                                        :duration duration
+                                        :users users
+                                        :context context
+                                        :error-file error-file-path
+                                        :default-progress-tracker default-progress-tracker
+                                        :progress-tracker progress-tracker}))))
 
 (defn run-two-scenarios [scenario1 scenario2 & {:keys [concurrency requests]}]
-  (to-vector (simulation/run {:name "Simulation"
-                              :scenarios [scenario1 scenario2]}
-                             {:concurrency concurrency
-                              :requests requests
-                              :timeout-in-ms 5000
-                              :error-file error-file-path
-                              :progress-tracker (fn [_])})))
+  (to-vector (:results (simulation/run {:name "Simulation"
+                                        :scenarios [scenario1 scenario2]}
+                                       {:concurrency concurrency
+                                        :requests requests
+                                        :timeout-in-ms 5000
+                                        :error-file error-file-path
+                                        :progress-tracker (fn [_])}))))
 
 (defn successful-request [cb context]
   ;;TODO Try to find a better way for this

--- a/test/clj_gatling/test_helpers.clj
+++ b/test/clj_gatling/test_helpers.clj
@@ -47,6 +47,7 @@
                                               requests
                                               duration
                                               users
+                                              default-progress-tracker
                                               progress-tracker
                                               pre-hook
                                               post-hook]
@@ -66,6 +67,7 @@
                               :users users
                               :context context
                               :error-file error-file-path
+                              :default-progress-tracker default-progress-tracker
                               :progress-tracker progress-tracker})))
 
 (defn run-two-scenarios [scenario1 scenario2 & {:keys [concurrency requests]}]


### PR DESCRIPTION
New key `force-stop-fn` is added to progress tracker argument map
which makes it possible to stop the simulation. Simulation is not
killed immediately. On going scenarios/requests are finalised first.

Solves: https://github.com/mhjort/clj-gatling/issues/72