### PR TITLE
Fix/progress should not exceed one

### DIFF
--- a/src/clj_gatling/simulation_runners.clj
+++ b/src/clj_gatling/simulation_runners.clj
@@ -14,7 +14,8 @@
     (let [time-taken (Duration/between ^LocalDateTime start ^LocalDateTime now)
           time-taken-in-millis (.toMillis time-taken)
           duration-in-millis (max (.toMillis duration) 1)]
-      [(float (/ time-taken-in-millis duration-in-millis)) time-taken]))
+      ;; Progress should not exceed 1.0 eventhough more than max duration might pass before simulation finishes
+      [(min 1.0 (float (/ time-taken-in-millis duration-in-millis))) time-taken]))
   (continue-run? [_ _ start next]
     (.isBefore ^LocalDateTime next (.plus ^LocalDateTime start duration)))
   (runner-info [_] (str "duration " duration)))

--- a/src/clj_gatling/simulation_runners.clj
+++ b/src/clj_gatling/simulation_runners.clj
@@ -23,7 +23,8 @@
   RunnerProtocol
   (calculate-progress [_ sent-requests start now]
     (let [time-taken (Duration/between ^LocalDateTime start ^LocalDateTime now)]
-      [(float (/ sent-requests number-of-requests)) time-taken]))
+      ;; Progress should not exceed 1.0 eventhough more than max requests might be sent before simulation finishes
+      [(min 1.0 (float (/ sent-requests number-of-requests))) time-taken]))
   (continue-run? [_ sent-requests _ _]
     (< sent-requests number-of-requests))
   (runner-info [_] (str "number of requests " number-of-requests)))

--- a/test/clj_gatling/simulation_runners_test.clj
+++ b/test/clj_gatling/simulation_runners_test.clj
@@ -1,0 +1,17 @@
+(ns clj-gatling.simulation-runners-test
+  (:require [clojure.test :refer [deftest testing is]]
+            [clj-gatling.simulation-runners :refer [calculate-progress]])
+  (:import (java.time Duration LocalDateTime)
+           (clj_gatling.simulation_runners FixedRequestNumberRunner)))
+
+(deftest fixed-request-number-runner
+  (let [runner (FixedRequestNumberRunner. 10)
+        now (LocalDateTime/now)]
+    (testing "Progress is 0.0 when no requests have been sent"
+      (is (= [0.0 (Duration/ofSeconds 0)] (calculate-progress runner 0 now now))))
+    (testing "Progress is 0.5 when half the requests have been sent"
+      (is (= [0.5 (Duration/ofSeconds 0)] (calculate-progress runner 5 now now))))
+    (testing "Progress is 1.0 when all the requests have been sent"
+      (is (= [1.0 (Duration/ofSeconds 0)] (calculate-progress runner 10 now now))))
+    (testing "Progress is 1.0 when more than max the requests have been sent"
+      (is (= [1.0 (Duration/ofSeconds 0)] (calculate-progress runner 12 now now))))))

--- a/test/clj_gatling/simulation_runners_test.clj
+++ b/test/clj_gatling/simulation_runners_test.clj
@@ -2,7 +2,19 @@
   (:require [clojure.test :refer [deftest testing is]]
             [clj-gatling.simulation-runners :refer [calculate-progress]])
   (:import (java.time Duration LocalDateTime)
-           (clj_gatling.simulation_runners FixedRequestNumberRunner)))
+           (clj_gatling.simulation_runners DurationRunner FixedRequestNumberRunner)))
+
+(deftest duration-runner
+  (let [runner (DurationRunner. (Duration/ofSeconds 10))
+        now (LocalDateTime/now)]
+    (testing "Progress is 0.0 when no time has passed"
+      (is (= [0.0 (Duration/ofSeconds 0)] (calculate-progress runner 0 now now))))
+    (testing "Progress is 0.5 when half the time has been passed"
+      (is (= [0.5 (Duration/ofSeconds 5)] (calculate-progress runner 0 now (.plusSeconds now 5)))))
+    (testing "Progress is 1.0 when time has passed"
+      (is (= [1.0 (Duration/ofSeconds 10)] (calculate-progress runner 10 now (.plusSeconds now 10)))))
+    (testing "Progress is 1.0 when more than max time has passed"
+      (is (= [1.0 (Duration/ofSeconds 12)] (calculate-progress runner 10 now (.plusSeconds now 12)))))))
 
 (deftest fixed-request-number-runner
   (let [runner (FixedRequestNumberRunner. 10)


### PR DESCRIPTION
Progress should be always a float between 0.0 and 1.0. Simulation does not end immediately and in some cases some extra requests might be sent above the max requests when simulation is ending. Same thing can happen with the duration. In those cases progress was incorrectly more than 1.0. Now this has been fixed