### PR TITLE
Improve simulation startup results

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clj-gatling "0.17.5"
+(defproject clj-gatling "0.17.6"
   :description "Clojure library for load testing"
   :url "http://github.com/mhjort/clj-gatling"
   :license {:name "Eclipse Public License"

--- a/src/clj_gatling/core.clj
+++ b/src/clj_gatling/core.clj
@@ -37,6 +37,7 @@
         scenarios (legacy-scenarios->scenarios legacy-scenarios)
         {:keys [results]} (simulation/run-scenarios {:runner (choose-runner scenarios concurrency options)
                                                      :timeout-in-ms step-timeout
+                                                     :concurrency concurrency
                                                      :context (:context options)
                                                      :error-file (or (:error-file options)
                                                                      (path-join results-dir "error.log"))

--- a/src/clj_gatling/progress_tracker.clj
+++ b/src/clj_gatling/progress_tracker.clj
@@ -4,11 +4,16 @@
             (java.util.concurrent Executors TimeUnit)))
 
 (defn create-console-progress-tracker []
-  (let [finished? (atom false)]
+  (let [finished? (atom false)
+        width     (atom 0)]
     (fn [{:keys [progress sent-requests total-concurrency]}]
       (when-not @finished?
-        (let [progress-percent (int (* 100 progress))]
-          (print (str "Progress: " progress-percent "%, concurrency: " total-concurrency " , sent requests: " sent-requests "\r"))
+        (let [progress-percent (int (* 100 progress))
+              report-str (str "Progress: " progress-percent "%, concurrency: " total-concurrency " , sent requests: " sent-requests)
+              [previous-width new-width] (swap-vals! width (fn [_] (count report-str)))
+              length-diff (- previous-width new-width)
+              blanking (if (< 0 length-diff) (apply str (repeat length-diff " ")) "")]
+          (print report-str blanking "\r")
           (when (= 100 progress-percent)
             (reset! finished? true)
             (println ""))
@@ -19,7 +24,7 @@
                      default-progress-tracker
                      runner
                      force-stop-fn
-                     sent-requests
+                     simulation-requests
                      start-time
                      scenario-concurrency-trackers]}]
   (let [executor (Executors/newSingleThreadScheduledExecutor)
@@ -27,10 +32,11 @@
                   (.shutdownNow executor))
         runnable (fn []
                    (try
-                     (let [[progress _] (runners/calculate-progress runner @sent-requests start-time (LocalDateTime/now))
+                     (let [sent-requests (:sent @simulation-requests)
+                           [progress _]  (runners/calculate-progress runner sent-requests @start-time (LocalDateTime/now))
                            total-concurrency (reduce + (map deref (vals scenario-concurrency-trackers)))]
                        (progress-tracker {:progress progress
-                                          :sent-requests @sent-requests
+                                          :sent-requests sent-requests
                                           :total-concurrency total-concurrency
                                           :default-progress-tracker default-progress-tracker
                                           :force-stop-fn force-stop-fn}))

--- a/src/clj_gatling/simulation_runners.clj
+++ b/src/clj_gatling/simulation_runners.clj
@@ -11,21 +11,25 @@
 (deftype DurationRunner [^Duration duration]
   RunnerProtocol
   (calculate-progress [_ _ start now]
-    (let [time-taken (Duration/between ^LocalDateTime start ^LocalDateTime now)
-          time-taken-in-millis (.toMillis time-taken)
-          duration-in-millis (max (.toMillis duration) 1)]
-      ;; Progress should not exceed 1.0 eventhough more than max duration might pass before simulation finishes
-      [(min 1.0 (float (/ time-taken-in-millis duration-in-millis))) time-taken]))
+    (if (or (nil? start) (nil? now))
+      [0.0 (Duration/ZERO)]
+      (let [time-taken (Duration/between ^LocalDateTime start ^LocalDateTime now)
+            time-taken-in-millis (.toMillis time-taken)
+            duration-in-millis (max (.toMillis duration) 1)]
+        ;; Progress should not exceed 1.0 even though more than max duration might pass before simulation finishes
+        [(min 1.0 (float (/ time-taken-in-millis duration-in-millis))) time-taken])))
   (continue-run? [_ _ start next]
-    (.isBefore ^LocalDateTime next (.plus ^LocalDateTime start duration)))
+    (or (nil? start) (.isBefore ^LocalDateTime next (.plus ^LocalDateTime start duration))))
   (runner-info [_] (str "duration " duration)))
 
 (deftype FixedRequestNumberRunner [number-of-requests]
   RunnerProtocol
   (calculate-progress [_ sent-requests start now]
-    (let [time-taken (Duration/between ^LocalDateTime start ^LocalDateTime now)]
-      ;; Progress should not exceed 1.0 eventhough more than max requests might be sent before simulation finishes
-      [(min 1.0 (float (/ sent-requests number-of-requests))) time-taken]))
+    (if (or (nil? start) (nil? now))
+      [0.0 (Duration/ZERO)]
+      (let [time-taken (Duration/between ^LocalDateTime start ^LocalDateTime now)]
+        ;; Progress should not exceed 1.0 even though more than max requests might be sent before simulation finishes
+        [(min 1.0 (float (/ sent-requests number-of-requests))) time-taken])))
   (continue-run? [_ sent-requests _ _]
     (< sent-requests number-of-requests))
   (runner-info [_] (str "number of requests " number-of-requests)))

--- a/test/clj_gatling/example.clj
+++ b/test/clj_gatling/example.clj
@@ -3,5 +3,9 @@
 (def test-simu
   {:name "Test simulation"
    :scenarios [{:name "Test scenario"
-                :steps [{:name "Step1" :request (fn [_] true)}
-                        {:name "Step2" :request (fn [_] false)}]}]})
+                :steps [{:name "Step1" :request (fn [_]
+                                                  (Thread/sleep 10)
+                                                  true)}
+                        {:name "Step2" :request (fn [_]
+                                                  (Thread/sleep 10)
+                                                  false)}]}]})

--- a/test/clj_gatling/pipeline_test.clj
+++ b/test/clj_gatling/pipeline_test.clj
@@ -31,6 +31,10 @@
                                                                                       :batch-size 10
                                                                                       :reporters reporters})]
     ;;Stub reporter returns number of batches parsed per reporter
+    (Thread/sleep 250)
     (force-stop-fn) ;;Makes sure that calling force-stop-fn does not throw an exception
-    (is (= {:a 3 :b 3} @summary))
+    (is (< 0 (:a @summary)))
+    (is (> 25 (:a @summary)))
+    (is (< 0 (:b @summary)))
+    (is (> 25 (:b @summary)))
     (is (= #{0 1 2} @node-ids))))

--- a/test/clj_gatling/simulation_runners_test.clj
+++ b/test/clj_gatling/simulation_runners_test.clj
@@ -7,6 +7,8 @@
 (deftest duration-runner
   (let [runner (DurationRunner. (Duration/ofSeconds 10))
         now (LocalDateTime/now)]
+    (testing "Progress is 0.0 when start has not yet been set"
+      (is (= [0.0 (Duration/ofSeconds 0)] (calculate-progress runner 0 nil now))))
     (testing "Progress is 0.0 when no time has passed"
       (is (= [0.0 (Duration/ofSeconds 0)] (calculate-progress runner 0 now now))))
     (testing "Progress is 0.5 when half the time has been passed"
@@ -19,6 +21,8 @@
 (deftest fixed-request-number-runner
   (let [runner (FixedRequestNumberRunner. 10)
         now (LocalDateTime/now)]
+    (testing "Progress is 0.0 when start has not yet been set"
+      (is (= [0.0 (Duration/ofSeconds 0)] (calculate-progress runner 0 nil now))))
     (testing "Progress is 0.0 when no requests have been sent"
       (is (= [0.0 (Duration/ofSeconds 0)] (calculate-progress runner 0 now now))))
     (testing "Progress is 0.5 when half the requests have been sent"


### PR DESCRIPTION
# Overview

Optimise `clj-gatling` test startup to avoid large reported latency spikes that are actually due to `clj-gatling` struggling on load, rather than the system-under-test struggling to handle the request rate.

# Why

This aims to improve the results we've been seeing when trying to run 'heavyweight' simulations with `clj-gatling`. Specifically, we are using `clojure.spec.alpha` and `clojure.spec.gen.alpha` in scenario pre-hooks to generate the data we want to use within the tests. We did try pre-generating all the data, but because of the length of test we wanted this just meant we ran out of heap space...

At low user/max concurrency numbers, the existing setup works more or less OK. However at high user numbers, especially when there are a lot of objects to generate per run, we are seeing a pretty big latency spike at the test start, which is skewing results.

Initially, we thought this was at the system-under-test end, as often happens when systems recieve a lot of load suddenly and have to scale to handle it, but further testing showed it was actually a problem within
`clj-gatling` itself. The problem is also present (albiet less seriously) even without heavyweight pre-hooks, when max concurrency is high. This is simply because `clj-gatling` is trying to spin up a load of new runners, single threaded, while simultaneously handling the first of the scenario runs via `core.async`.

# What

1. Swap the `map` where we create all the different per-user scenario runs for a `pmap`, so we utilise all the cores available when running the pre-hooks/creating the scenario runners.
2. Implement an 'initialisation synchronisation' mechanism, so that all the runners must be ready to go before any of them start sending requests. We also generate the context data (call pre-hooks) for those inital requests before reporting ready. Calling all those pre-hooks in parallel generates a lot of unhelpful load on the `clj-gatling` host
that affects reported timing, whereas subsequent requests are natually jittery enough from differences in response times from the system under test that it's fine to regenerate ad-hoc.
3. Turn `simulation-start` into an `atom`, that only gets set when all runners are ready to go. This avoids a problem that is particularly bad in the `rate` runner, where the first few runners started can't keep up with the required rate, so once more _do_ start up there is a higher-than-intended rush of requests to make up the backlog. Various progress functions etc have been amended to handle this being an atom/`nil`.
4. Fix a bug where the `rate` runner considered a full scenario to be a single request (and decided whether to continue running or not based on that), whereas actual sent requests were counted per-step in each scenario. To aid this, a function has been created which identifies the number of requests a scenario is expected to make. Most of the time this is known exactly. In the cases where it is not, a best effort guess is made, which should get more accurate as more simulation runs occur.
In terms of requests, a simulation is now considered good to run if the total of sent+pending requests _before_ this run's expected count is added is less than the max. To aid that, the sent+pending atoms have been collapsed into a single atom, so that both values can be read... atomically. Adding this logic into the concurrent runner too has
improved test reliability.
5. Improve the testing `is-approximately-sorted?` function, which allows us to compare without dropping data, and to provide an accuracy that we want to hit as a target.
6. Increase some test request counts. Target/actual scenario runs tend to diverge a lot more than expected
when the total test duration (either directly, or from a low max request count) is very low. This has not noticeably affected the overall test suite duration.
7. Stop the progress reporter from looking odd when the line length shortens between refreshes, and the sent-messages count looks masssively too large.

For reference, this is what a rate of 400 scenarios/sec looks like previously:
<img width="935" alt="Screenshot 2022-07-27 at 14 12 27" src="https://user-images.githubusercontent.com/12294221/181255822-fa23b366-6585-4780-bd78-267c0d8554b6.png">

And this is what it looks like now:
<img width="926" alt="Screenshot 2022-07-27 at 14 12 37" src="https://user-images.githubusercontent.com/12294221/181255872-eb7bc56f-83c9-4110-8a28-c0dad6f567c2.png">


