### PR TITLE
Improve test reliability

### DIFF
--- a/src/clj_gatling/simulation_util.clj
+++ b/src/clj_gatling/simulation_util.clj
@@ -49,7 +49,10 @@
         ;;In this tool this is not an issue
         xs (map #(max 1 (int (* total (/ % sum-weights)))) weights)
         mismatch (- total (reduce + xs))]
-    (map #(+ %1 %2) xs (concat (repeat mismatch 1) (repeat total 0)))))
+    (if (nat-int? mismatch)
+      (map #(+ %1 %2) xs (concat (repeat mismatch 1) (repeat total 0)))
+      (throw (ex-info "Negative remainder found when splitting by weight. Increase total or reduce weight variance"
+                      {:total total :weights weights})))))
 
 (defn split-to-buckets [ids bucket-sizes]
   (loop [start-idx 0

--- a/test/clj_gatling/simulation_test.clj
+++ b/test/clj_gatling/simulation_test.clj
@@ -682,9 +682,9 @@
         request-count (count (map :requests results))]
     (is (< request-count 1000))
     ;; There is a race condition between calling the force-stop-fn and sending
-    ;; more requests, and test requests are very fast, so this will be a little
+    ;; more requests, and test requests are very fast, so this could be a little
     ;; out
-    (is (= request-count @sent-requests-when-force-stop-requested))))
+    (is (some #{@sent-requests-when-force-stop-requested} (range request-count (+ request-count 3))))))
 
 (deftest with-step-fn
   (let [result (run-single-scenario {:name "scenario"


### PR DESCRIPTION
Fixes https://github.com/mhjort/clj-gatling/issues/84

Decided to have a look at this as it was one of the tests that failed
and prevented 0.17.6 from being released.

If a very small number of users is specified, close/equal to the number
of scenarios, and the scenario weights are very diverse, you can get a
situation where more users than exist are assigned across the scenarios
(because each must have at least 1 user, you can get a negative
`mismatch` in `split-by-weight` caused by rounding errors across the
users and weights divisions).

Rather than try all sorts of complex maths to deal with this, I opted to
just throw an explicit error detailing the issue in this (edge) case,
and modify the generated tests so that they shouldn't hit it (as well as
creating an expicit test _for_ it).

Sometimes, because we now start more threads than concurrency calls for
and each checks to see if it should run or not, we can be a little out
in some of the tests. We can't use `approximately==` here, because the
number we _actually_ expect is normally pretty close to 1, but might be 2
or 3, and we don't want a test that allows a multi-hundred-percent
difference if that number for some reason jumps to 100 or something.

As such, we simply check that the result is within a range from the
expected number to 1 or 2 higher (it shouldn't ever be lower).

Hopefully this will mean 0.17.6 can actually get released.