### PR TITLE
Fix a bug of using incorrect concurrency with multiple scenarios

### DIFF
--- a/src/clj_gatling/pipeline.clj
+++ b/src/clj_gatling/pipeline.clj
@@ -92,7 +92,9 @@
                    context] :as options}]
   (let [users-by-node (if rate
                         (split-equally nodes (range (max-users rate timeout-in-ms)))
-                        (split-equally nodes (range (* concurrency 5))))
+                        ;When running simulation using concurrency mode the number of users
+                        ;must match exactly to the number of users
+                        (split-equally nodes (range concurrency)))
         requests-by-node (when requests
                            (split-number-equally nodes requests))
         report-generators (init-report-generators reporters results-dir context)

--- a/test/clj_gatling/test_helpers.clj
+++ b/test/clj_gatling/test_helpers.clj
@@ -66,7 +66,7 @@
                                         :timeout-in-ms timeout-in-ms
                                         :requests requests
                                         :duration duration
-                                        :users (or users (range (* concurrency 5)))
+                                        :users (or users (range concurrency))
                                         :context context
                                         :error-file error-file-path
                                         :default-progress-tracker default-progress-tracker


### PR DESCRIPTION
PR87 contained a lot of performance optimisations to clj-gatling itself. https://github.com/mhjort/clj-gatling/pull/87

Unfortunately it also introduced a bug where end concurrency was incorrect with multiple scenarios. When using rate mode it makes sense to create bunch of spare users. However, with concurrency mode we should not have more users than the total concurrency is.

This commit also adds a test where multiscenario simulation is run and progress tracker is used for checking that actual concurrency in simulation is correct.

This PR fixes: https://github.com/mhjort/clj-gatling/issues/92